### PR TITLE
Add option to disable building of test code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ option(WITH_STATIC_DEFAULTS "Enable statically linked in default materials" ON)
 option(HAVE_SPACENAV_SUPPORT "Enable Space Navigator support" ON)
 option(SO${GUI}_USE_CPACK "If enabled the cpack subrepo is mandatory" OFF)
 option(SO${GUI}_BUILD_DOCUMENTATION "Build and install API documentation (requires Doxygen)." OFF)
+option(SO${GUI}_BUILD_TESTS "Build small test programs." ON)
 cmake_dependent_option(SO${GUI}_BUILD_INTERNAL_DOCUMENTATION "Document internal code not part of the API." OFF "SO${GUI}_BUILD_DOCUMENTATION" OFF)
 cmake_dependent_option(SO${GUI}_BUILD_DOC_MAN "Build So${Gui} man pages." OFF "SO${GUI}_BUILD_DOCUMENTATION" OFF)
 cmake_dependent_option(SO${GUI}_BUILD_DOC_QTHELP "Build QtHelp documentation." OFF "SO${GUI}_BUILD_DOCUMENTATION" OFF)
@@ -390,7 +391,9 @@ set(PACKAGE_REQUIREMENTS "Coin, ${PACKAGE_ADDITIONAL_REQUIREMENTS}")
 add_subdirectory(data)
 add_subdirectory(src)
 ##### small test programs (to be run interactively)
-add_subdirectory(test-code)
+if (SO${GUI}_BUILD_TESTS)
+  add_subdirectory(test-code)
+endif()
 
 ############################################################################
 # New CPACK section, please see the README file inside cpack.d directory.


### PR DESCRIPTION
It should be possible to disable building of the optional test code without modifying the source code, e.g., for various packaging systems.