### PR TITLE
Fixed Qt Wdeprecated-declarations warnings

### DIFF
--- a/src/Inventor/Qt/SoQtGLWidget.cpp
+++ b/src/Inventor/Qt/SoQtGLWidget.cpp
@@ -192,7 +192,7 @@ SoQtGLWidget::SoQtGLWidget(QWidget * const parent,
 #endif
   PRIVATE(this)->wasresized = false;
 
-  PRIVATE(this)->glformat = new QGLFormat();
+  PRIVATE(this)->glformat = new QGLFormat(QGLFormat::defaultFormat());
   PRIVATE(this)->glformat->setDoubleBuffer((glmodes & SO_GL_DOUBLE) ? true : false);
   PRIVATE(this)->glformat->setDepth((glmodes & SO_GL_ZBUFFER) ? true : false);
   PRIVATE(this)->glformat->setRgba((glmodes & SO_GL_RGB) ? true : false);

--- a/src/Inventor/Qt/SoQtGLWidget.cpp
+++ b/src/Inventor/Qt/SoQtGLWidget.cpp
@@ -192,7 +192,7 @@ SoQtGLWidget::SoQtGLWidget(QWidget * const parent,
 #endif
   PRIVATE(this)->wasresized = false;
 
-  PRIVATE(this)->glformat = new QGLFormat(0);
+  PRIVATE(this)->glformat = new QGLFormat();
   PRIVATE(this)->glformat->setDoubleBuffer((glmodes & SO_GL_DOUBLE) ? true : false);
   PRIVATE(this)->glformat->setDepth((glmodes & SO_GL_ZBUFFER) ? true : false);
   PRIVATE(this)->glformat->setRgba((glmodes & SO_GL_RGB) ? true : false);

--- a/src/Inventor/Qt/devices/SoQtMouse.cpp
+++ b/src/Inventor/Qt/devices/SoQtMouse.cpp
@@ -117,10 +117,23 @@ SoQtMouse::translateEvent(QEvent * event)
 
 #ifdef HAVE_SOMOUSEBUTTONEVENT_BUTTON5
   if (wheelevent) {
+#if QT_VERSION >= 0x050700
+    if (wheelevent->angleDelta().y() > 0)
+      PRIVATE(this)->buttonevent->setButton(wheelevent->inverted() ? SoMouseButtonEvent::BUTTON5 : SoMouseButtonEvent::BUTTON4);
+    else if (wheelevent->angleDelta().y() < 0)
+      PRIVATE(this)->buttonevent->setButton(wheelevent->inverted() ? SoMouseButtonEvent::BUTTON4 : SoMouseButtonEvent::BUTTON5);
+#elif QT_VERSION >= 0x050000
     if (wheelevent->angleDelta().y() > 0)
       PRIVATE(this)->buttonevent->setButton(SoMouseButtonEvent::BUTTON4);
     else if (wheelevent->angleDelta().y() < 0)
       PRIVATE(this)->buttonevent->setButton(SoMouseButtonEvent::BUTTON5);
+#else
+    if (wheelevent->delta() > 0)
+      PRIVATE(this)->buttonevent->setButton(SoMouseButtonEvent::BUTTON4);
+    else if (wheelevent->delta() < 0)
+      PRIVATE(this)->buttonevent->setButton(SoMouseButtonEvent::BUTTON5);
+#endif // QT_VERSION
+
 #if SOQT_DEBUG
     else {
       SoDebugError::postInfo("SoQtMouse::translateEvent",
@@ -264,7 +277,12 @@ SoQtMouse::translateEvent(QEvent * event)
       conv->setCtrlDown(wheelevent->state() & Qt::ControlButton);
       conv->setAltDown(wheelevent->state() & Qt::AltButton);
 #endif
+
+#if QT_VERSION >= 0x050E00
       this->setEventPosition(conv, wheelevent->position().x(), wheelevent->position().y());
+#else
+      this->setEventPosition(conv, wheelevent->x(), wheelevent->y());
+#endif // QT_VERSION
     }
 
     // FIXME: should be time of Qt event. 19990211 mortene.

--- a/src/Inventor/Qt/devices/SoQtMouse.cpp
+++ b/src/Inventor/Qt/devices/SoQtMouse.cpp
@@ -117,9 +117,9 @@ SoQtMouse::translateEvent(QEvent * event)
 
 #ifdef HAVE_SOMOUSEBUTTONEVENT_BUTTON5
   if (wheelevent) {
-    if (wheelevent->delta() > 0)
+    if (wheelevent->angleDelta().y() > 0)
       PRIVATE(this)->buttonevent->setButton(SoMouseButtonEvent::BUTTON4);
-    else if (wheelevent->delta() < 0)
+    else if (wheelevent->angleDelta().y() < 0)
       PRIVATE(this)->buttonevent->setButton(SoMouseButtonEvent::BUTTON5);
 #if SOQT_DEBUG
     else {
@@ -264,7 +264,7 @@ SoQtMouse::translateEvent(QEvent * event)
       conv->setCtrlDown(wheelevent->state() & Qt::ControlButton);
       conv->setAltDown(wheelevent->state() & Qt::AltButton);
 #endif
-      this->setEventPosition(conv, wheelevent->x(), wheelevent->y());
+      this->setEventPosition(conv, wheelevent->position().x(), wheelevent->position().y());
     }
 
     // FIXME: should be time of Qt event. 19990211 mortene.


### PR DESCRIPTION
Fixes these warnings:

```cpp
soqt/src/Inventor/Qt/SoQtGLWidget.cpp:195:44: warning: »constexpr QFlags<T>::QFlags(QFlags<T>::Zero) [mit Enum = QGL::FormatOption; QFlags<T>::Zero = int QFlags<QGL::FormatOption>::Private::*]« is deprecated: Use default constructor instead [-Wdeprecated-declarations]
  195 |   PRIVATE(this)->glformat = new QGLFormat(0);
```

```cpp
src/Inventor/Qt/devices/SoQtMouse.cpp:120:27: warning: 'int QWheelEvent::delta() const' is deprecated: Use angleDelta() [-Wdeprecated-declarations]
  120 |     if (wheelevent->delta() > 0)
```

```cpp
soqt/src/Inventor/Qt/devices/SoQtMouse.cpp:267:50: warning: 'int QWheelEvent::x() const' is deprecated: Use position() [-Wdeprecated-declarations]
  267 |       this->setEventPosition(conv, wheelevent->x(), wheelevent->y());
```