### PR TITLE
Add a CMake option to disable the use of X11 libraries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+#VI temp files
+*.swp
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ option(SO${GUI}_VERBOSE "Verbose build " OFF)
 option(COIN_IV_EXTENSIONS "Enable extra Open Inventor extensions" ON)
 option(SO${GUI}_BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(SO${GUI}_USE_QT5 "Prefer Qt5 over Qt4 if available" ON)
+option(SO${GUI}_USE_X11 "Enable use of X11 libraries. [if OFF, SoQt will be not linked against X11]" ON)
 option(WITH_STATIC_DEFAULTS "Enable statically linked in default materials" ON)
 option(HAVE_SPACENAV_SUPPORT "Enable Space Navigator support" ON)
 option(SO${GUI}_USE_CPACK "If enabled the cpack subrepo is mandatory" OFF)
@@ -146,7 +147,6 @@ else()
   set(SO${GUI}_PKG_DEPS "${SO${GUI}_PKG_DEPS} QtCore QtGui QtOpenGL")
 endif()
 
-find_package(X11)
 
 # ##########################################################################
 # Setup build environment
@@ -371,12 +371,21 @@ if(HAVE_WINDOWS_H)
 endif()
 set(USE_EXCEPTIONS ON)
 set(HAVE_JOYSTICK_LINUX OFF)
-check_include_files(X11/Xlib.h HAVE_X11_AVAILABLE)
-if(HAVE_X11_AVAILABLE)
-  set(X_DISPLAY_MISSING 0)
-  check_include_files(X11/extensions/SGIMisc.h HAVE_X11_EXTENSIONS_SGIMISC_H)
-  check_include_files(X11/extensions/XInput.h HAVE_X11_EXTENSIONS_XINPUT_H)
-  check_include_files(X11/Xproto.h HAVE_X11_XPROTO_H)
+
+# Use X11. 
+# Users can disable this. Especially useful on macOS, where X11 is not needed. 
+# Default is TRUE.
+if(SO${GUI}_USE_X11)
+  find_package(X11)
+  check_include_files(X11/Xlib.h HAVE_X11_AVAILABLE)
+  if(HAVE_X11_AVAILABLE)
+    set(X_DISPLAY_MISSING 0)
+    check_include_files(X11/extensions/SGIMisc.h HAVE_X11_EXTENSIONS_SGIMISC_H)
+    check_include_files(X11/extensions/XInput.h HAVE_X11_EXTENSIONS_XINPUT_H)
+    check_include_files(X11/Xproto.h HAVE_X11_XPROTO_H)
+  else()
+    set(X_DISPLAY_MISSING 1)
+  endif()
 else()
   set(X_DISPLAY_MISSING 1)
 endif()


### PR DESCRIPTION
An underlying linking to X11 is currently performed, even on platforms
where it is not needed, like macOS.

That also prevents the portability of pre-compiled packages built on a
version of macOS to another macOS machine. If XQuartz (the macOS X11
package) is, in fact, installed on the build machine, the output library
is then silently linked to X11; then, X11 becomes a dependency of the
the package on the client machine, even if not needed.

This is a breaker, for instance, when building Homebrew packages.

The option lets users explicitly disable the use of X11.

**A note:** I'm not aware of potential uses of X11 linking on macOS. If no
use cases are foreseen, we could even disable the use of X11 completely
for SoQt on macOS, as it has been done for Coin:
https://github.com/coin3d/coin/commit/58a1b4c3e968f96d3a2091fa5cb625f360ce6811

----

This PR also adds a `.gitignore` file to the `soqt` root folder, initially populated with VI temp files (`*.swp`).
